### PR TITLE
improve gathering of artifacts

### DIFF
--- a/istio-proxy/bazel_get_workspace_status
+++ b/istio-proxy/bazel_get_workspace_status
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ -z "${BUILD_SCM_REVISION}" ]; then
+  if git rev-parse --verify --quiet HEAD >/dev/null; then
+    BUILD_SCM_REVISION="$(git rev-parse --short --verify HEAD)"
+  else
+    exit 1
+  fi
+fi
+
+if [ -z "${BUILD_SCM_STATUS}" ]; then
+  BUILD_SCM_STATUS="Maistra"
+fi
+
+echo "BUILD_SCM_REVISION ${BUILD_SCM_REVISION}"
+echo "BUILD_SCM_STATUS ${BUILD_SCM_STATUS}"
+

--- a/istio-proxy/test.sh
+++ b/istio-proxy/test.sh
@@ -1,4 +1,4 @@
-set -x 
+set -x
 set -e
 
 function set_default_envs() {
@@ -36,7 +36,12 @@ function run_tests() {
           sed -i 's|TEST_F|TEST|g' src/istio/mixerclient/check_cache_test.cc
         fi
 
-        bazel --output_base=${RPM_BUILD_DIR}/istio-proxy-${PROXY_GIT_BRANCH}/istio-proxy/bazel/base --output_user_root=${RPM_BUILD_DIR}/istio-proxy-${PROXY_GIT_BRANCH}/istio-proxy/bazel/root --batch test --config=${BUILD_CONFIG} "//..."
+        if [ "${BUILD_CONFIG}" == 'debug' ]; then
+          bazel --output_base=${RPM_BUILD_DIR}/istio-proxy-${PROXY_GIT_BRANCH}/istio-proxy/bazel/base --output_user_root=${RPM_BUILD_DIR}/istio-proxy-${PROXY_GIT_BRANCH}/istio-proxy/bazel/root --batch test -c dbg "//..."
+        else
+          bazel --output_base=${RPM_BUILD_DIR}/istio-proxy-${PROXY_GIT_BRANCH}/istio-proxy/bazel/base --output_user_root=${RPM_BUILD_DIR}/istio-proxy-${PROXY_GIT_BRANCH}/istio-proxy/bazel/root --batch test --config=${BUILD_CONFIG} "//..."
+        fi
+
       fi
     popd
   fi


### PR DESCRIPTION
This commit adds more flexibility to gather the artifacts for the proxy build.

It also adds:

- option to build debug artifact (by setting BUILD_CONFIG='debug')
- creation of a sha256 hash file for the artifacts
- rolls back the use of 'checkout' so we can build proxy based on commits (i.e. using SHA)
- remove external_deps var from python patch
- add workspace status to envoy version