### PR TITLE
[MAISTRA-686] Added update.sh

### DIFF
--- a/istio-proxy/istio-proxy.spec
+++ b/istio-proxy/istio-proxy.spec
@@ -49,7 +49,7 @@ BuildRequires:  cmake3
 BuildRequires:  openssl
 BuildRequires:  openssl-devel
 
-Source0:        istio-proxy.%{checksum}.tar.xz
+Source0:        istio-proxy.%{git_commit}.tar.xz
 Source1:        build.sh
 Source2:        test.sh
 Source3:        fetch.sh

--- a/istio-proxy/update.sh
+++ b/istio-proxy/update.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+NEW_SOURCES=""
+
+function usage() {
+	echo "Usage: $0 [-i <SHA of istio>]"
+	echo
+	exit 0
+}
+
+while getopts ":i:v:" opt; do
+	case ${opt} in
+		i) PROXY_SHA="${OPTARG}";;
+		*) usage;;
+	esac
+done
+
+[[ -z "${PROXY_SHA}" ]] && PROXY_SHA="$(grep '%global git_commit ' istio-proxy.spec | cut -d' ' -f3)"
+
+function update_commit() {
+		sha=$1
+		echo
+		echo "Updating spec file with $1"
+    sed -i "s/%global git_commit .*/%global git_commit ${sha}/" istio-proxy.spec
+}
+
+function new_sources() {
+	sha=$1
+	echo
+	echo "Updating sources file with ${sha}"
+	md5sum ${sha} > sources
+}
+
+function get_sources() {
+	FETCH_DIR=/tmp CREATE_TARBALL=true ./fetch.sh
+	TAR_NAME=istio-proxy.${PROXY_SHA}.tar.xz
+	cp -p /tmp/proxy-full.tar.xz ${TAR_NAME}
+
+	new_sources ${TAR_NAME}
+	md5sum ${TAR_NAME} > sources
+}
+
+update_commit "${PROXY_SHA}"
+get_sources "" "${PROXY_SHA}"

--- a/istio/buildinfo
+++ b/istio/buildinfo
@@ -4,4 +4,3 @@ istio.io/istio/pkg/version.buildUser=redhat
 istio.io/istio/pkg/version.buildHost=redhat
 istio.io/istio/pkg/version.buildDockerHub=docker.io/maistra
 istio.io/istio/pkg/version.buildStatus=Clean
-\


### PR DESCRIPTION
This PR updates istio proxy to use the update.sh system used by the rest of the Istio components. 

Usage
========
./update.sh -i SHA updates istio-proxy.spec. 

Results
==========
* updated sources file (if commit changed) 
* update istio-proxy.spec (if commit changed)
* a .tar.xz containing the proxy-sources. 

How to use the .tar.xz
==========================
Once the .tar.xz is generated, the standard commands such as fedpkg --release el8 srpm can be used to build the actual srpm and submit to the build system.