### PR TITLE
[MAISTRA-686] Added update.sh

### DIFF
--- a/istio-proxy/istio-proxy.spec
+++ b/istio-proxy/istio-proxy.spec
@@ -49,7 +49,7 @@ BuildRequires:  cmake3
 BuildRequires:  openssl
 BuildRequires:  openssl-devel
 
-Source0:        istio-proxy.%{checksum}.tar.xz
+Source0:        istio-proxy.%{git_commit}.tar.xz
 Source1:        build.sh
 Source2:        test.sh
 Source3:        fetch.sh

--- a/istio-proxy/istio-proxy.spec
+++ b/istio-proxy/istio-proxy.spec
@@ -49,7 +49,7 @@ BuildRequires:  cmake3
 BuildRequires:  openssl
 BuildRequires:  openssl-devel
 
-Source0:        istio-proxy.%{git_commit}.tar.xz
+Source0:        istio-proxy.%{checksum}.tar.xz
 Source1:        build.sh
 Source2:        test.sh
 Source3:        fetch.sh

--- a/istio-proxy/update.sh
+++ b/istio-proxy/update.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+NEW_SOURCES=""
+
+function usage() {
+	echo "Usage: $0 [-i <SHA of istio>]"
+	echo
+	exit 0
+}
+
+while getopts ":i:v:" opt; do
+	case ${opt} in
+		i) PROXY_SHA="${OPTARG}";;
+		*) usage;;
+	esac
+done
+
+[[ -z "${PROXY_SHA}" ]] && PROXY_SHA="$(grep '%global git_commit ' istio-proxy.spec | cut -d' ' -f3)"
+
+function update_commit() {
+		sha=$1
+		echo
+		echo "Updating spec file with $1"
+    sed -i "s/%global git_commit .*/%global git_commit ${sha}/" istio-proxy.spec
+}
+
+function new_sources() {
+	sha=$1
+	echo
+	echo "Updating sources file with ${sha}"
+	md5sum ${sha} > sources
+}
+
+function get_sources() {
+	FETCH_DIR=/tmp CREATE_TARBALL=true ./fetch.sh
+	TAR_NAME=istio-proxy.${PROXY_SHA}.tar.xz
+	cp -p /tmp/proxy-full.tar.xz ${TAR_NAME}
+
+	new_sources ${TAR_NAME}
+	md5sum ${TAR_NAME} > sources
+}
+
+update_commit "${PROXY_SHA}"
+get_sources "" "${PROXY_SHA}"

--- a/istio-proxy/update.sh
+++ b/istio-proxy/update.sh
@@ -20,7 +20,7 @@ function update_commit() {
 		local sha=$1
 		echo
 		echo "Updating spec file with ${sha}"
-    sed -i "s/%global git_commit .*/%global git_commit ${sha}/" istio-proxy.spec
+		sed -i "s/%global git_commit .*/%global git_commit ${sha}/" istio-proxy.spec
 }
 
 function new_sources() {
@@ -33,7 +33,7 @@ function new_sources() {
 function get_sources() {
 	local proxy_sha=$1
 	FETCH_DIR=/tmp CREATE_TARBALL=true ./fetch.sh
-	local tar_name=istio-proxy.${1}.tar.xz
+	local tar_name=istio-proxy.${proxy_sha}.tar.xz
 	cp -p /tmp/proxy-full.tar.xz ${tar_name}
 
 	new_sources ${tar_name}

--- a/istio-proxy/update.sh
+++ b/istio-proxy/update.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
-NEW_SOURCES=""
-
+PROXY_SHA=""
 function usage() {
 	echo "Usage: $0 [-i <SHA of istio>]"
 	echo
 	exit 0
 }
 
-while getopts ":i:v:" opt; do
+while getopts ":i:" opt; do
 	case ${opt} in
 		i) PROXY_SHA="${OPTARG}";;
 		*) usage;;
@@ -18,27 +17,28 @@ done
 [[ -z "${PROXY_SHA}" ]] && PROXY_SHA="$(grep '%global git_commit ' istio-proxy.spec | cut -d' ' -f3)"
 
 function update_commit() {
-		sha=$1
+		local sha=$1
 		echo
-		echo "Updating spec file with $1"
+		echo "Updating spec file with ${sha}"
     sed -i "s/%global git_commit .*/%global git_commit ${sha}/" istio-proxy.spec
 }
 
 function new_sources() {
-	sha=$1
+	local filename=$1
 	echo
-	echo "Updating sources file with ${sha}"
-	md5sum ${sha} > sources
+	echo "Updating sources file with ${filename}"
+	md5sum ${filename} > sources
 }
 
 function get_sources() {
+	local proxy_sha=$1
 	FETCH_DIR=/tmp CREATE_TARBALL=true ./fetch.sh
-	TAR_NAME=istio-proxy.${PROXY_SHA}.tar.xz
-	cp -p /tmp/proxy-full.tar.xz ${TAR_NAME}
+	local tar_name=istio-proxy.${1}.tar.xz
+	cp -p /tmp/proxy-full.tar.xz ${tar_name}
 
-	new_sources ${TAR_NAME}
-	md5sum ${TAR_NAME} > sources
+	new_sources ${tar_name}
+	md5sum ${tar_name} > sources
 }
 
 update_commit "${PROXY_SHA}"
-get_sources "" "${PROXY_SHA}"
+get_sources "${PROXY_SHA}"

--- a/istio-proxy/update.sh
+++ b/istio-proxy/update.sh
@@ -28,6 +28,13 @@ function new_sources() {
 	echo
 	echo "Updating sources file with ${filename}"
 	md5sum ${filename} > sources
+	local checksum=$(awk '{print $1}' sources)
+
+	sed -i "s/%global checksum .*/%global checksum ${checksum}/" istio-proxy.spec
+
+	local checksumFilename=istio-proxy.${checksum}.tar.xz
+	mv $filename $checksumFilename
+	sed -i "s/${filename}/${checksumFilename}/" sources
 }
 
 function get_sources() {
@@ -37,7 +44,7 @@ function get_sources() {
 	cp -p /tmp/proxy-full.tar.xz ${tar_name}
 
 	new_sources ${tar_name}
-	md5sum ${tar_name} > sources
+
 }
 
 update_commit "${PROXY_SHA}"


### PR DESCRIPTION
This PR updates istio proxy to use the update.sh system used by the rest of the Istio components. 

Usage
========
./update.sh -i SHA updates istio-proxy.spec. 

Results
==========
* updated sources file (if commit changed) 
* update istio-proxy.spec (if commit changed)
* a .tar.xz containing the proxy-sources. 

How to use the .tar.xz
==========================
Once the .tar.xz is generated, the standard commands such as fedpkg --release el8 srpm can be used to build the actual srpm and submit to the build system.