### PR TITLE
[Maistra-1244] [Maistra-1245] Make buildinfo update version

### DIFF
--- a/istio/buildinfo
+++ b/istio/buildinfo
@@ -2,5 +2,4 @@ istio.io/pkg/version.buildVersion=1.1.0
 istio.io/pkg/version.buildGitRevision=b0f47f26fa67a352fc95db7ecd2af902d7879221
 istio.io/pkg/version.buildUser=redhat
 istio.io/pkg/version.buildHost=redhat
-istio.io/pkg/version.buildDockerHub=docker.io/maistra
 istio.io/pkg/version.buildStatus=Clean

--- a/istio/buildinfo
+++ b/istio/buildinfo
@@ -1,6 +1,6 @@
-istio.io/istio/pkg/version.buildVersion=1.1.0
-istio.io/istio/pkg/version.buildGitRevision=b0f47f26fa67a352fc95db7ecd2af902d7879221
-istio.io/istio/pkg/version.buildUser=redhat
-istio.io/istio/pkg/version.buildHost=redhat
-istio.io/istio/pkg/version.buildDockerHub=docker.io/maistra
-istio.io/istio/pkg/version.buildStatus=Clean
+istio.io/pkg/version.buildVersion=1.1.0
+istio.io/pkg/version.buildGitRevision=b0f47f26fa67a352fc95db7ecd2af902d7879221
+istio.io/pkg/version.buildUser=redhat
+istio.io/pkg/version.buildHost=redhat
+istio.io/pkg/version.buildDockerHub=docker.io/maistra
+istio.io/pkg/version.buildStatus=Clean

--- a/istio/istio.spec
+++ b/istio/istio.spec
@@ -377,7 +377,7 @@ tar zxf %{SOURCE0} -C ISTIO/src/istio.io/istio --strip=1
 
 cp %{SOURCE1} ISTIO/src/istio.io/istio/.istiorc.mk
 
-sed -i "s/istio.io\/istio\/pkg\/version.buildVersion=.*/istio.io\/istio\/pkg\/version.buildVersion="%{version}"/" %{SOURCE2}
+sed -i "s/istio.io\/pkg\/version.buildVersion=.*/istio.io\/pkg\/version.buildVersion="%{version}"/" %{SOURCE2}
 cp %{SOURCE2} ISTIO/src/istio.io/istio/buildinfo
 
 %build

--- a/istio/istio.spec
+++ b/istio/istio.spec
@@ -377,7 +377,7 @@ tar zxf %{SOURCE0} -C ISTIO/src/istio.io/istio --strip=1
 
 cp %{SOURCE1} ISTIO/src/istio.io/istio/.istiorc.mk
 
-sed -i "s/istio.io\/pkg\/version.buildVersion=.*/istio.io\/pkg\/version.buildVersion="%{version}"/" %{SOURCE2}
+sed -i "s|istio.io/pkg/version\.buildVersion=.*|istio.io/pkg/version.buildVersion="%{version}"|" %{SOURCE2}
 cp %{SOURCE2} ISTIO/src/istio.io/istio/buildinfo
 
 %build

--- a/istio/istio.spec
+++ b/istio/istio.spec
@@ -376,6 +376,8 @@ mkdir -p ISTIO/src/istio.io/istio
 tar zxf %{SOURCE0} -C ISTIO/src/istio.io/istio --strip=1
 
 cp %{SOURCE1} ISTIO/src/istio.io/istio/.istiorc.mk
+
+sed -i "s/istio.io\/istio\/pkg\/version.buildVersion=.*/istio.io\/istio\/pkg\/version.buildVersion="%{version}"/" %{SOURCE2}
 cp %{SOURCE2} ISTIO/src/istio.io/istio/buildinfo
 
 %build
@@ -391,7 +393,6 @@ touch ${ISTIO_OUT}/version.helm.${HELM_VER}
 
 ENVOY=/tmp/envoy-dummy
 touch ${ENVOY}
- 
 
 pushd src/istio.io/istio
 GOBUILDFLAGS="-mod=vendor" ISTIO_ENVOY_LINUX_DEBUG_PATH=${ENVOY} ISTIO_ENVOY_LINUX_RELEASE_PATH=${ENVOY} make pilot-discovery pilot-agent sidecar-injector mixc mixs istio_ca istioctl galley

--- a/istio/update.sh
+++ b/istio/update.sh
@@ -50,6 +50,10 @@ function new_sources() {
 function update_buildinfo() {
     local sha="$1"
     sed -i "s/buildGitRevision=.*/buildGitRevision=${sha}/" buildinfo
+
+		version=$(grep 'Version:' istio.spec | cut -d' ' -f9)
+
+		sed -i "s/istio.io\/istio\/pkg\/version.buildVersion=.*/istio.io\/istio\/pkg\/version.buildVersion=${version}/" buildinfo
 }
 
 update_commit "" "${ISTIO_SHA}"

--- a/istio/update.sh
+++ b/istio/update.sh
@@ -50,10 +50,6 @@ function new_sources() {
 function update_buildinfo() {
     local sha="$1"
     sed -i "s/buildGitRevision=.*/buildGitRevision=${sha}/" buildinfo
-
-		version=$(grep 'Version:' istio.spec | cut -d' ' -f9)
-
-		sed -i "s/istio.io\/istio\/pkg\/version.buildVersion=.*/istio.io\/istio\/pkg\/version.buildVersion=${version}/" buildinfo
 }
 
 update_commit "" "${ISTIO_SHA}"


### PR DESCRIPTION
Thought we already had this, but update.sh isn't updating buildinfo. This PR fixes it. 