### PR TITLE
MAISTRA-1281: Print version and SHA in the output of --version

### DIFF
--- a/istio-proxy/bazel_get_workspace_status
+++ b/istio-proxy/bazel_get_workspace_status
@@ -1,17 +1,4 @@
 #!/bin/bash
 
-if [ -z "${BUILD_SCM_REVISION}" ]; then
-  if git rev-parse --verify --quiet HEAD >/dev/null; then
-    BUILD_SCM_REVISION="$(git rev-parse --short --verify HEAD)"
-  else
-    exit 1
-  fi
-fi
-
-if [ -z "${BUILD_SCM_STATUS}" ]; then
-  BUILD_SCM_STATUS="Maistra"
-fi
-
-echo "BUILD_SCM_REVISION ${BUILD_SCM_REVISION}"
-echo "BUILD_SCM_STATUS ${BUILD_SCM_STATUS}"
-
+echo "BUILD_SCM_REVISION @REVISION@"
+echo "BUILD_SCM_STATUS Maistra @VERSION@"

--- a/istio-proxy/fetch.sh
+++ b/istio-proxy/fetch.sh
@@ -70,10 +70,6 @@ function set_default_envs() {
     FETCH_OR_BUILD=fetch
   fi
 
-  if [ -z "${BUILD_SCM_REVISION}" ]; then
-    BUILD_SCM_REVISION=$(date +%s)
-  fi
-
   if [ -z "${STRIP_LATOMIC}" ]; then
     STRIP_LATOMIC=true
   fi
@@ -146,10 +142,6 @@ function remove_build_artifacts() {
   rm -rf bazel/base/external/envoy_deps_cache_*
 }
 
-function copy_bazel_build_status(){
-  cp -f ${RPM_SOURCE_DIR}/bazel_get_workspace_status ${PROXY_FETCH_DIR}/proxy/tools/bazel_get_workspace_status
-}
-
 function replace_python() {
 
   pushd ${CACHE_DIR}
@@ -174,7 +166,6 @@ function fetch() {
       extract_dependency "proxy" "${PROXY_GIT_REPO}" "${PROXY_GIT_COMMIT_HASH}"
       use_local_envoy
       add_patches
-      copy_bazel_build_status
 
       bazel_dir="bazel"
       if [ "${DEBUG_FETCH}" == "true" ]; then
@@ -294,12 +285,6 @@ function use_local_envoy(){
       WORKSPACE
   popd
   use_local_go
-}
-
-function add_BUILD_SCM_REVISIONS(){
-  pushd ${PROXY_FETCH_DIR}/proxy
-    sed -i "1i BUILD_SCM_REVISION=${BUILD_SCM_REVISION}\n" tools/bazel_get_workspace_status
-  popd
 }
 
 function patch_class_memaccess() {
@@ -447,7 +432,6 @@ remove_build_artifacts
 add_path_markers
 #add_cxx_params
 replace_ssl
-add_BUILD_SCM_REVISIONS
 correct_links
 add_annobin_flags
 local_envoy_path_markers

--- a/istio-proxy/istio-proxy.spec
+++ b/istio-proxy/istio-proxy.spec
@@ -55,6 +55,7 @@ Source1:        build.sh
 Source2:        test.sh
 Source3:        fetch.sh
 Source4:        common.sh
+Source5:        bazel_get_workspace_status
 
 %description
 The Istio Proxy is a microservice proxy that can be used on the client and server side, and forms a microservice mesh. The Proxy supports a large number of features.
@@ -72,6 +73,8 @@ istio-proxy is the proxy required by the Istio Pilot Agent that talks to Istio p
 
 %prep
 %setup -q -n %{name}
+
+sed -e "s/@REVISION@/%{proxy_git_commit}/" -e "s/@VERSION@/%{version}-%{release}/" %{SOURCE5} > proxy/tools/bazel_get_workspace_status
 
 %build
 


### PR DESCRIPTION
Before:
```
envoy  version: 1584322855/1.12.0/Maistra/...
```

After:
```
envoy  version: e885dd6880407edd27c81f8f42c5480a6d80751d/1.12.0/Maistra 1.1.0-1.el8/...
```

We don't need to perform this operation beforehand (fetch phase), we can take
the same approach as Istio package and run this at RPM build phase.